### PR TITLE
Split HW traits to support different configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-graphics",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "epd-waveshare-async",
  "panic-probe",

--- a/epd-waveshare-async/src/epd2in9.rs
+++ b/epd-waveshare-async/src/epd2in9.rs
@@ -5,7 +5,7 @@ use embedded_graphics::{
     primitives::Rectangle,
 };
 use embedded_hal::{
-    digital::OutputPin,
+    digital::{OutputPin, PinState},
     spi::{Phase, Polarity},
 };
 use embedded_hal_async::delay::DelayNs;
@@ -81,6 +81,11 @@ pub const RECOMMENDED_SPI_PHASE: Phase = Phase::CaptureOnFirstTransition;
 /// Use this polarity in conjunction with [RECOMMENDED_SPI_PHASE] so that the EPD can capture data
 /// on the rising edge.
 pub const RECOMMENDED_SPI_POLARITY: Polarity = Polarity::IdleLow;
+/// The default pin state that indicates the display is busy.
+///
+/// Note: the datasheet states that busy pin is active low, i.e. we should wait for it when
+/// it's low, but this is incorrect. The sample code treats it as active high, which works.
+pub const DEFAULT_BUSY_WHEN: PinState = PinState::High;
 
 /// Low-level commands for the Epd2In9. You probably want to use the other methods exposed on the
 /// [Epd2In9] for most operations, but can send commands directly with [Epd2In9::send] for low-level

--- a/epd-waveshare-async/src/epd2in9.rs
+++ b/epd-waveshare-async/src/epd2in9.rs
@@ -12,9 +12,9 @@ use embedded_hal_async::delay::DelayNs;
 
 use crate::{
     buffer::{binary_buffer_length, split_low_and_high, BinaryBuffer, BufferView},
-    hw::CommandDataSend as _,
+    hw::{BusyHw, DcHw, DelayHw, ErrorHw, ResetHw},
     log::{debug, debug_assert},
-    DisplayPartial, DisplaySimple, Displayable, EpdHw, Reset, Sleep, Wake,
+    DisplayPartial, DisplaySimple, Displayable, Reset, Sleep, SpiHw, Wake,
 };
 
 /// LUT for a full refresh. This should be used occasionally for best display results.
@@ -226,18 +226,18 @@ impl<W: StateAwake> State for StateAsleep<W> {}
 /// * [sample code](https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py)
 ///
 /// The display has a portrait orientation. This uses [BinaryColor], where `Off` is black and `On` is white.
-pub struct Epd2In9<HW, STATE>
-where
-    HW: EpdHw,
-    STATE: State,
-{
+pub struct Epd2In9<HW, STATE> {
     hw: HW,
     state: STATE,
 }
 
 impl<HW> Epd2In9<HW, StateUninitialized>
 where
-    HW: EpdHw,
+    HW: DcHw + ResetHw + BusyHw + DelayHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
 {
     pub fn new(hw: HW) -> Self {
         Epd2In9 {
@@ -249,8 +249,12 @@ where
 
 impl<HW, STATE> Epd2In9<HW, STATE>
 where
-    HW: EpdHw,
+    HW: DcHw + ResetHw + BusyHw + DelayHw + ErrorHw + SpiHw,
     STATE: StateAwake,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
 {
     /// Initialise the display. This should be called before any other operations.
     pub async fn init(
@@ -291,7 +295,16 @@ where
         epd.set_refresh_mode_impl(spi, mode).await?;
         Ok(epd)
     }
+}
 
+impl<HW, STATE> Epd2In9<HW, STATE>
+where
+    HW: DcHw + BusyHw + ErrorHw + SpiHw,
+    STATE: StateAwake,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+{
     /// Sets the border to the specified colour. You need to call [Epd::update_display] using
     /// [RefreshMode::Full] afterwards to apply this change.
     ///
@@ -317,11 +330,18 @@ where
         command: Command,
         data: &[u8],
     ) -> Result<(), HW::Error> {
+        use crate::hw::CommandDataSend;
         self.hw.send(spi, command.register(), data).await
     }
 }
 
-impl<HW: EpdHw> Epd2In9<HW, StateReady> {
+impl<HW> Epd2In9<HW, StateReady>
+where
+    HW: DcHw + BusyHw + DelayHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+{
     /// Sets the refresh mode.
     pub async fn set_refresh_mode(
         &mut self,
@@ -345,7 +365,7 @@ impl<HW: EpdHw> Epd2In9<HW, StateReady> {
         &mut self,
         spi: &mut HW::Spi,
         shape: Rectangle,
-    ) -> Result<(), <HW as EpdHw>::Error> {
+    ) -> Result<(), HW::Error> {
         // Use a debug assert as this is a soft failure in production; it will just lead to
         // slightly misaligned display content.
         let x_start = shape.top_left.x;
@@ -380,7 +400,7 @@ impl<HW: EpdHw> Epd2In9<HW, StateReady> {
         &mut self,
         spi: &mut HW::Spi,
         position: Point,
-    ) -> Result<(), <HW as EpdHw>::Error> {
+    ) -> Result<(), HW::Error> {
         // Use a debug assert as this is a soft failure in production; it will just lead to
         // slightly misaligned display content.
         debug_assert_eq!(position.x % 8, 0, "position.x must be 8-bit aligned");
@@ -419,8 +439,14 @@ impl<HW: EpdHw> Epd2In9<HW, StateReady> {
     }
 }
 
-impl<HW: EpdHw> Displayable<HW::Spi, HW::Error> for Epd2In9<HW, StateReady> {
-    async fn update_display(&mut self, spi: &mut HW::Spi) -> Result<(), <HW as EpdHw>::Error> {
+impl<HW> Displayable<HW::Spi, HW::Error> for Epd2In9<HW, StateReady>
+where
+    HW: DcHw + BusyHw + DelayHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+{
+    async fn update_display(&mut self, spi: &mut HW::Spi) -> Result<(), HW::Error> {
         // Enable the clock and CP (?), and then display the data from the RAM. Note that there are
         // two RAM buffers, so this will swap the active buffer. Calling this function twice in a row
         // without writing further to RAM therefore results in displaying the previous image.
@@ -441,14 +467,19 @@ impl<HW: EpdHw> Displayable<HW::Spi, HW::Error> for Epd2In9<HW, StateReady> {
     }
 }
 
-impl<HW: EpdHw> DisplaySimple<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateReady> {
+impl<HW> DisplaySimple<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateReady>
+where
+    HW: DcHw + BusyHw + DelayHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+{
     async fn display_framebuffer(
         &mut self,
         spi: &mut HW::Spi,
         buf: &dyn BufferView<1, 1>,
     ) -> Result<(), HW::Error> {
         self.write_framebuffer(spi, buf).await?;
-
         self.update_display(spi).await
     }
 
@@ -464,7 +495,13 @@ impl<HW: EpdHw> DisplaySimple<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateRea
     }
 }
 
-impl<HW: EpdHw> DisplayPartial<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateReady> {
+impl<HW> DisplayPartial<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateReady>
+where
+    HW: DcHw + BusyHw + DelayHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+{
     /// Writes buffer data into the old internal framebuffer. This can be useful either:
     ///
     /// * to prep the next frame before the current one has been displayed (since the old buffer
@@ -474,7 +511,7 @@ impl<HW: EpdHw> DisplayPartial<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateRe
         &mut self,
         spi: &mut HW::Spi,
         buf: &dyn BufferView<1, 1>,
-    ) -> Result<(), <HW as EpdHw>::Error> {
+    ) -> Result<(), HW::Error> {
         let buffer_bounds = buf.window();
         self.set_window(spi, buffer_bounds).await?;
         self.set_cursor(spi, buffer_bounds.top_left).await?;
@@ -482,7 +519,11 @@ impl<HW: EpdHw> DisplayPartial<1, 1, HW::Spi, HW::Error> for Epd2In9<HW, StateRe
     }
 }
 
-async fn reset_impl<HW: EpdHw>(hw: &mut HW) -> Result<(), HW::Error> {
+async fn reset_impl<HW>(hw: &mut HW) -> Result<(), HW::Error>
+where
+    HW: ResetHw + DelayHw + ErrorHw,
+    HW::Error: From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>,
+{
     debug!("Resetting EPD");
     // Assume reset is already high.
     hw.reset().set_low()?;
@@ -492,7 +533,12 @@ async fn reset_impl<HW: EpdHw>(hw: &mut HW) -> Result<(), HW::Error> {
     Ok(())
 }
 
-impl<HW: EpdHw, STATE: StateAwake> Reset<HW::Error> for Epd2In9<HW, STATE> {
+impl<HW, STATE> Reset<HW::Error> for Epd2In9<HW, STATE>
+where
+    HW: ResetHw + DelayHw + ErrorHw,
+    HW::Error: From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>,
+    STATE: StateAwake,
+{
     type DisplayOut = Epd2In9<HW, STATE>;
 
     async fn reset(mut self) -> Result<Self::DisplayOut, HW::Error> {
@@ -501,7 +547,12 @@ impl<HW: EpdHw, STATE: StateAwake> Reset<HW::Error> for Epd2In9<HW, STATE> {
     }
 }
 
-impl<HW: EpdHw, W: StateAwake> Reset<HW::Error> for Epd2In9<HW, StateAsleep<W>> {
+impl<HW, W> Reset<HW::Error> for Epd2In9<HW, StateAsleep<W>>
+where
+    HW: ResetHw + DelayHw + ErrorHw,
+    HW::Error: From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>,
+    W: StateAwake,
+{
     type DisplayOut = Epd2In9<HW, W>;
 
     async fn reset(mut self) -> Result<Self::DisplayOut, HW::Error> {
@@ -513,10 +564,18 @@ impl<HW: EpdHw, W: StateAwake> Reset<HW::Error> for Epd2In9<HW, StateAsleep<W>> 
     }
 }
 
-impl<HW: EpdHw, STATE: StateAwake> Sleep<HW::Spi, HW::Error> for Epd2In9<HW, STATE> {
+impl<HW, STATE> Sleep<HW::Spi, HW::Error> for Epd2In9<HW, STATE>
+where
+    HW: DcHw + BusyHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Dc as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+    STATE: StateAwake,
+{
     type DisplayOut = Epd2In9<HW, StateAsleep<STATE>>;
 
-    async fn sleep(mut self, spi: &mut HW::Spi) -> Result<Self::DisplayOut, <HW as EpdHw>::Error> {
+    async fn sleep(mut self, spi: &mut HW::Spi) -> Result<Self::DisplayOut, HW::Error>
+where {
         debug!("Sleeping EPD");
         self.send(spi, Command::DeepSleepMode, &[0x01]).await?;
         Ok(Epd2In9 {
@@ -528,13 +587,19 @@ impl<HW: EpdHw, STATE: StateAwake> Sleep<HW::Spi, HW::Error> for Epd2In9<HW, STA
     }
 }
 
-impl<HW: EpdHw, W: StateAwake> Wake<HW::Spi, HW::Error> for Epd2In9<HW, StateAsleep<W>> {
+impl<HW, W> Wake<HW::Spi, HW::Error> for Epd2In9<HW, StateAsleep<W>>
+where
+    HW: ResetHw + BusyHw + DelayHw + ErrorHw + SpiHw,
+    HW::Error: From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Busy as embedded_hal::digital::ErrorType>::Error>
+        + From<<HW::Spi as embedded_hal_async::spi::ErrorType>::Error>,
+    W: StateAwake,
+{
     type DisplayOut = Epd2In9<HW, W>;
 
-    async fn wake(self, _spi: &mut HW::Spi) -> Result<Self::DisplayOut, <HW as EpdHw>::Error> {
+    async fn wake(self, _spi: &mut HW::Spi) -> Result<Self::DisplayOut, HW::Error> {
         debug!("Waking EPD");
         self.reset().await
-
         // Confirmed with a physical screen that init is not required after waking.
     }
 }

--- a/epd-waveshare-async/src/epd2in9_v2.rs
+++ b/epd-waveshare-async/src/epd2in9_v2.rs
@@ -4,7 +4,7 @@ use embedded_graphics::{
     primitives::Rectangle,
 };
 use embedded_hal::{
-    digital::OutputPin,
+    digital::{OutputPin, PinState},
     spi::{Phase, Polarity},
 };
 use embedded_hal_async::delay::DelayNs;
@@ -178,6 +178,8 @@ pub const RECOMMENDED_SPI_PHASE: Phase = Phase::CaptureOnFirstTransition;
 /// Use this polarity in conjunction with [RECOMMENDED_SPI_PHASE] so that the EPD can capture data
 /// on the rising edge.
 pub const RECOMMENDED_SPI_POLARITY: Polarity = Polarity::IdleLow;
+/// The default pin state that indicates the display is busy.
+pub const DEFAULT_BUSY_WHEN: PinState = PinState::High;
 
 /// Low-level commands for the Epd2In9 v2 display. You probably want to use the other methods
 /// exposed on the [Epd2In9V2] for most operations, but can send commands directly with [Epd2In9V2::send] for low-level

--- a/epd-waveshare-async/src/hw.rs
+++ b/epd-waveshare-async/src/hw.rs
@@ -1,4 +1,3 @@
-use core::error::Error as CoreError;
 
 use embedded_hal::{
     digital::{ErrorType as PinErrorType, InputPin, OutputPin},
@@ -13,7 +12,7 @@ use crate::log::trace;
 /// Drivers rely on this trait to provide a single Error type that supports [From] conversions
 /// from all the hardware-specific error types.
 pub trait ErrorHw {
-    type Error: CoreError + From<crate::Error>;
+    type Error;
 }
 
 /// Describes the SPI hardware to use for interacting with the EPD.

--- a/epd-waveshare-async/src/hw.rs
+++ b/epd-waveshare-async/src/hw.rs
@@ -8,106 +8,49 @@ use embedded_hal_async::{delay::DelayNs, digital::Wait, spi::SpiDevice};
 
 use crate::log::trace;
 
-/// Provides access to the hardware needed to control an EPD.
+/// Provides access to a shared error type.
 ///
-/// This greatly simplifies the generics needed by the `Epd` trait and implementing types at the cost of implementing this trait.
-///
-/// In this example, we make the EPD generic over just the SPI type, but can drop generics for the pins and delay type.
-///
-/// ```rust
-/// use core::convert::Infallible;
-///
-/// use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
-/// use embassy_embedded_hal::shared_bus::SpiDeviceError;
-/// use embassy_rp::gpio::{Input, Output};
-/// use embassy_rp::spi::{self, Spi};
-/// use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-/// use embassy_time::Delay;
-/// use epd_waveshare_async::{EpdHw, Error as EpdError};
-/// use thiserror::Error as ThisError;
-///
-/// /// Define an error type that can convert from the SPI and GPIO errors.
-/// #[derive(Debug, ThisError)]
-/// enum Error {
-///   #[error("SPI error: {0:?}")]
-///   SpiError(SpiDeviceError<spi::Error, Infallible>),
-///   #[error("Display error: {0:?}")]
-///   DisplayError(EpdError),
-/// }
-///
-/// impl From<Infallible> for Error {
-///     fn from(_: Infallible) -> Self {
-///         // GPIO errors are infallible, i.e. they can't occur, so this should be unreachable.
-///         unreachable!()
-///     }
-/// }
-///
-/// impl From<SpiDeviceError<spi::Error, Infallible>> for Error {
-///     fn from(e: SpiDeviceError<spi::Error, Infallible>) -> Self {
-///         Error::SpiError(e)
-///     }
-/// }
-///
-/// impl From<EpdError> for Error {
-///     fn from(e: EpdError) -> Self {
-///         Error::DisplayError(e)
-///     }
-/// }
-///
-/// struct RpEpdHw<'a, SPI: spi::Instance + 'a> {
-///     dc: Output<'a>,
-///     reset: Output<'a>,
-///     busy: Input<'a>,
-///     delay: Delay,
-///     _phantom: core::marker::PhantomData<SPI>,
-/// }
-///
-/// impl <'a, SPI: spi::Instance + 'a> EpdHw for RpEpdHw<'a, SPI> {
-///     type Spi = SpiDevice<'a, CriticalSectionRawMutex, Spi<'a, SPI, spi::Async>, Output<'a>>;
-///     type Dc = Output<'a>;
-///     type Reset = Output<'a>;
-///     type Busy = Input<'a>;
-///     type Delay = Delay;
-///     type Error = Error;
-///
-///     fn dc(&mut self) -> &mut Self::Dc {
-///       &mut self.dc
-///     }
-///
-///     fn reset(&mut self) -> &mut Self::Reset {
-///       &mut self.reset
-///     }
-///
-///     fn busy(&mut self) -> &mut Self::Busy {
-///       &mut self.busy
-///     }
-///
-///     fn delay(&mut self) -> &mut Self::Delay {
-///       &mut self.delay
-///     }
-/// }
-/// ```
-pub trait EpdHw {
+/// Drivers rely on this trait to provide a single Error type that supports [From] conversions
+/// from all the hardware-specific error types.
+pub trait ErrorHw {
+    type Error: CoreError + From<crate::Error>;
+}
+
+/// Describes the SPI hardware to use for interacting with the EPD.
+pub trait SpiHw {
     type Spi: SpiDevice;
+}
+
+/// Provides access to the Data/Command pin for EPD control.
+pub trait DcHw {
     type Dc: OutputPin;
-    type Reset: OutputPin;
-    type Busy: InputPin + Wait;
-    type Delay: DelayNs;
-    type Error: CoreError
-        + From<<Self::Spi as SpiErrorType>::Error>
-        + From<<Self::Dc as PinErrorType>::Error>
-        + From<<Self::Reset as PinErrorType>::Error>
-        + From<<Self::Busy as PinErrorType>::Error>
-        + From<crate::Error>;
 
     fn dc(&mut self) -> &mut Self::Dc;
+}
+
+/// Provides access to the Reset pin for EPD control.
+pub trait ResetHw {
+    type Reset: OutputPin;
+
     fn reset(&mut self) -> &mut Self::Reset;
+}
+
+/// Provides access to the Busy pin for EPD status monitoring.
+pub trait BusyHw {
+    type Busy: InputPin + Wait;
+
     fn busy(&mut self) -> &mut Self::Busy;
+}
+
+/// Provides access to delay functionality for EPD timing control.
+pub trait DelayHw {
+    type Delay: DelayNs;
+
     fn delay(&mut self) -> &mut Self::Delay;
 }
 
 /// Provides "wait" support for hardware with a busy state.
-pub(crate) trait BusyWait: EpdHw {
+pub(crate) trait BusyWait: ErrorHw {
     /// Waits for the current operation to complete if the display is busy.
     ///
     /// Note that this will wait forever if the display is asleep.
@@ -115,17 +58,21 @@ pub(crate) trait BusyWait: EpdHw {
 }
 
 /// Provides the ability to send <command> then <data> style communications.
-pub(crate) trait CommandDataSend: EpdHw {
+pub(crate) trait CommandDataSend: SpiHw + ErrorHw {
     /// Send the following command and data to the display. Waits until the display is no longer busy before sending.
     async fn send(
         &mut self,
-        spi: &mut <Self as EpdHw>::Spi,
+        spi: &mut Self::Spi,
         command: u8,
         data: &[u8],
     ) -> Result<(), Self::Error>;
 }
 
-impl<HW: EpdHw> BusyWait for HW {
+impl<HW> BusyWait for HW
+where
+    HW: BusyHw + ErrorHw,
+    <HW as ErrorHw>::Error: From<<HW::Busy as PinErrorType>::Error>,
+{
     async fn wait_if_busy(&mut self) -> Result<(), HW::Error> {
         let busy = self.busy();
         // Note: the datasheet states that busy pin is active low, i.e. we should wait for it when
@@ -138,10 +85,16 @@ impl<HW: EpdHw> BusyWait for HW {
     }
 }
 
-impl<HW: EpdHw> CommandDataSend for HW {
+impl<HW> CommandDataSend for HW
+where
+    HW: DcHw + BusyHw + BusyWait + SpiHw + ErrorHw,
+    HW::Error: From<<HW::Spi as SpiErrorType>::Error>
+        + From<<HW::Dc as PinErrorType>::Error>
+        + From<<HW::Busy as PinErrorType>::Error>,
+{
     async fn send(
         &mut self,
-        spi: &mut <Self as EpdHw>::Spi,
+        spi: &mut Self::Spi,
         command: u8,
         data: &[u8],
     ) -> Result<(), Self::Error> {

--- a/epd-waveshare-async/src/lib.rs
+++ b/epd-waveshare-async/src/lib.rs
@@ -43,7 +43,7 @@ mod hw;
 mod log;
 
 use crate::buffer::BufferView;
-pub use crate::hw::EpdHw;
+pub use crate::hw::{BusyHw, DcHw, DelayHw, ErrorHw, ResetHw, SpiHw};
 
 /// Indicates usage errors due to incorrect states.
 ///

--- a/epd-waveshare-async/src/lib.rs
+++ b/epd-waveshare-async/src/lib.rs
@@ -45,19 +45,6 @@ mod log;
 use crate::buffer::BufferView;
 pub use crate::hw::{BusyHw, DcHw, DelayHw, ErrorHw, ResetHw, SpiHw};
 
-/// Indicates usage errors due to incorrect states.
-///
-/// These errors are allowed to occur as runtime errors instead of being prevented at compile time
-/// through stateful types. The alternative was tried, but was awkward to use in practice since
-/// async traits are not dyn compatible.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, Clone)]
-pub enum Error {
-    Uninitialized,
-    Sleeping,
-    WrongRefreshMode,
-}
-
 /// Displays that have a hardware reset.
 pub trait Reset<ERROR> {
     type DisplayOut;

--- a/samples/rp/Cargo.toml
+++ b/samples/rp/Cargo.toml
@@ -21,6 +21,7 @@ panic-probe = { version = "1.0", features = ["print-defmt"] }
 
 defmt.workspace = true
 embedded-graphics.workspace = true
+embedded-hal.workspace = true
 embedded-hal-async.workspace = true
 epd-waveshare-async = { path = "../../epd-waveshare-async", features = ["defmt"] }
 embassy-time.workspace = true

--- a/samples/rp/src/bin/epd2in9.rs
+++ b/samples/rp/src/bin/epd2in9.rs
@@ -78,6 +78,7 @@ async fn main(_spawner: Spawner) {
         resources.epd_hw.dc,
         resources.epd_hw.reset,
         resources.epd_hw.busy,
+        epd2in9::DEFAULT_BUSY_WHEN,
     ));
 
     info!("Initializing EPD");

--- a/samples/rp/src/bin/epd2in9_v2.rs
+++ b/samples/rp/src/bin/epd2in9_v2.rs
@@ -78,6 +78,7 @@ async fn main(_spawner: Spawner) {
         resources.epd_hw.dc,
         resources.epd_hw.reset,
         resources.epd_hw.busy,
+        epd2in9_v2::DEFAULT_BUSY_WHEN,
     ));
 
     info!("Initializing EPD");

--- a/samples/rp/src/lib.rs
+++ b/samples/rp/src/lib.rs
@@ -11,6 +11,7 @@ use embassy_rp::spi;
 use embassy_rp::Peri;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::Delay;
+use embedded_hal::digital::PinState;
 use epd_waveshare_async::{BusyHw, DcHw, DelayHw, ErrorHw, ResetHw, SpiHw};
 use thiserror::Error as ThisError;
 use {defmt_rtt as _, panic_probe as _};
@@ -20,6 +21,7 @@ pub struct DisplayHw<'a, SPI> {
     dc: Output<'a>,
     reset: Output<'a>,
     busy: Input<'a>,
+    busy_when: PinState,
     delay: Delay,
     _spi_type: PhantomData<SPI>,
 }
@@ -29,6 +31,7 @@ impl<'a, SPI: spi::Instance> DisplayHw<'a, SPI> {
         dc: Peri<'a, DC>,
         reset: Peri<'a, RESET>,
         busy: Peri<'a, BUSY>,
+        busy_when: PinState,
     ) -> Self {
         let dc = Output::new(dc, Level::High);
         let reset = Output::new(reset, Level::High);
@@ -38,6 +41,7 @@ impl<'a, SPI: spi::Instance> DisplayHw<'a, SPI> {
             dc,
             reset,
             busy,
+            busy_when,
             delay: Delay,
             _spi_type: PhantomData,
         }
@@ -71,6 +75,10 @@ impl<'a, SPI> BusyHw for DisplayHw<'a, SPI> {
 
     fn busy(&mut self) -> &mut Self::Busy {
         &mut self.busy
+    }
+
+    fn busy_when(&self) -> embedded_hal::digital::PinState {
+        self.busy_when
     }
 }
 

--- a/samples/rp/src/lib.rs
+++ b/samples/rp/src/lib.rs
@@ -11,7 +11,7 @@ use embassy_rp::spi;
 use embassy_rp::Peri;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::Delay;
-use epd_waveshare_async::{BusyHw, DcHw, DelayHw, Error as EpdError, ErrorHw, ResetHw, SpiHw};
+use epd_waveshare_async::{BusyHw, DcHw, DelayHw, ErrorHw, ResetHw, SpiHw};
 use thiserror::Error as ThisError;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -90,8 +90,6 @@ impl<'a, SPI: spi::Instance + 'a> SpiHw for DisplayHw<'a, SPI> {
 pub enum Error {
     #[error("SPI error: {0:?}")]
     SpiError(RawSpiError),
-    #[error("Display error: {0:?}")]
-    DisplayError(EpdError),
 }
 
 impl From<Infallible> for Error {
@@ -103,11 +101,5 @@ impl From<Infallible> for Error {
 impl From<RawSpiError> for Error {
     fn from(e: RawSpiError) -> Self {
         Error::SpiError(e)
-    }
-}
-
-impl From<EpdError> for Error {
-    fn from(e: EpdError) -> Self {
-        Error::DisplayError(e)
     }
 }


### PR DESCRIPTION
This makes writing the drivers a little annoying, as they have to specify that `HW::Error` implements `From<X::Error>` for all the relevant hardware types `X`. But, this nuisance is limited to the driver implementations, and doesn't spill over to users of the library. 

To keep the boilerplate to a minimum, the type definitions put minimal constraints on their generic types (e.g. `Epd2In9` expects a `HW` and `STATE` of any type). Each each trait implementation then request just the minimal set of constraints it cares about.

For example, the `Reset` implementation just requires the hardware constraints `HW: ResetHw + DelayHw + ErrorHw` and `HW::Error: From<<HW::Reset as embedded_hal::digital::ErrorType>::Error>`.

To support both displays with different "busy" pin states, and different wiring configurations of the existing displays, the `BusyHw` trait now also requires a `busy_when()` function.