### PR TITLE
Fix fill_solid when not aligned to byte boundaries

### DIFF
--- a/epd-waveshare-async/src/buffer.rs
+++ b/epd-waveshare-async/src/buffer.rs
@@ -197,7 +197,7 @@ impl<const L: usize> DrawTarget for BinaryBuffer<L> {
         let x_start = drawable_area.top_left.x;
         let x_end = drawable_area.top_left.x + drawable_area.size.width as i32;
 
-        let x_full_bytes_start = min(x_start + (8 - x_start % 8) % 8, x_end);
+        let x_full_bytes_start = min((x_start + 7) & !7, x_end);
         let x_full_bytes_end = max(x_end - (x_end % 8), x_start);
         let num_full_bytes_per_row = (x_full_bytes_end - x_full_bytes_start) / 8;
 

--- a/epd-waveshare-async/src/buffer.rs
+++ b/epd-waveshare-async/src/buffer.rs
@@ -697,6 +697,38 @@ mod tests {
     }
 
     #[test]
+    fn test_binary_buffer_fill_solid_matches_draw_iter() {
+        // Tries a lot of start and width combinations (aligned and unaligned, including out of
+        // bounds) and checks that fill_solid produces the same result as setting each
+        // pixel individually with draw_iter.
+        const SIZE: Size = Size::new(24, 4);
+        const BUFFER_LENGTH: usize = binary_buffer_length(SIZE);
+        const MAX_PIXELS: usize = 2 * 32;
+
+        for color in [BinaryColor::On, BinaryColor::Off] {
+            for x_start in -4..28 {
+                for width in 0u32..=32 {
+                    let area = Rectangle::new(Point::new(x_start, 1), Size::new(width, 2));
+
+                    let mut fast = BinaryBuffer::<{ BUFFER_LENGTH }>::new(SIZE);
+                    fast.fill_solid(&area, color).unwrap();
+
+                    let mut reference = BinaryBuffer::<{ BUFFER_LENGTH }>::new(SIZE);
+                    let mut pixels: Vec<Pixel<BinaryColor>, MAX_PIXELS> = Vec::new();
+                    for y in 1..3 {
+                        for x in x_start..x_start + width as i32 {
+                            pixels.push(Pixel(Point::new(x, y), color)).unwrap();
+                        }
+                    }
+                    reference.draw_iter(pixels).unwrap();
+
+                    assert_eq!(fast.data, reference.data);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_gray2_split_buffer_draw_iter_singles() {
         const SIZE: Size = Size::new(16, 4);
         const BUFFER_LENGTH: usize = gray2_split_buffer_length(SIZE);

--- a/epd-waveshare-async/src/buffer.rs
+++ b/epd-waveshare-async/src/buffer.rs
@@ -197,7 +197,7 @@ impl<const L: usize> DrawTarget for BinaryBuffer<L> {
         let x_start = drawable_area.top_left.x;
         let x_end = drawable_area.top_left.x + drawable_area.size.width as i32;
 
-        let x_full_bytes_start = min(x_start + x_start % 8, x_end);
+        let x_full_bytes_start = min(x_start + (8 - x_start % 8) % 8, x_end);
         let x_full_bytes_end = max(x_end - (x_end % 8), x_start);
         let num_full_bytes_per_row = (x_full_bytes_end - x_full_bytes_start) / 8;
 


### PR DESCRIPTION
fill_solid currently corrupts rectangles with non-byte-aligned x_start.

x_full_bytes_start doesn't round up to the next byte boundary. It adds the remainder to itself instead.
Current formula: 
```rust
let x_full_bytes_start = min(x_start + x_start % 8, x_end);
```

Example (x_start = 126):
- current: 126 + 6 = 132 (not divisible by 8)
- fixed: 126 + (8 - 6) % 8 = 128

The correct formula is:
```rust
let x_full_bytes_start = min(x_start + (8 - x_start % 8) % 8, x_end);
```

Aligned starts (x_start % 8 == 0) were unaffected, which is also why the existing tests passed. Their rectangles are either aligned or too small to show the bug.

Current implementation shown on 4.2" V2 Waveshare epd:
<img width="1885" height="429" alt="current" src="https://github.com/user-attachments/assets/da4c4f9d-642f-41bf-916d-9737e87b23aa" />

Fixed implementation:
<img width="1459" height="515" alt="fixed" src="https://github.com/user-attachments/assets/91cee040-1643-4439-b133-4bcfb221154c" />

